### PR TITLE
Add snapcn to Components & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@
 | solanauth | A responsive Solana wallet authentication and account modal for Next.js, featuring NextAuth integration and shadcn/ui components for modern dApps. |  | [Demo](https://solanauth.vercel.app/) |  |
 | vaul | Vaul is a dedicated React component for implementing drawer UIs, offering a simple way to add interactive panels for navigation or content. |  | [Demo](https://vaul.emilkowal.ski/) |  |
 | animata | Discover a free, open-source library of hand-crafted ReactJS animations and interactive effects, designed for easy copy-paste integration into your applications. |  | [Demo](https://animata.design) |  |
+| snapcn | Video components that look like software, for Remotion: AI answer streams, terminal sessions, device frames, captions and full scenes. | [Github](https://github.com/snapcndev/snapcn.dev) | [Demo](https://snapcn.dev) |  |
 
 ## Boilerplates & Starters
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@
 | solanauth | A responsive Solana wallet authentication and account modal for Next.js, featuring NextAuth integration and shadcn/ui components for modern dApps. |  | [Demo](https://solanauth.vercel.app/) |  |
 | vaul | Vaul is a dedicated React component for implementing drawer UIs, offering a simple way to add interactive panels for navigation or content. |  | [Demo](https://vaul.emilkowal.ski/) |  |
 | animata | Discover a free, open-source library of hand-crafted ReactJS animations and interactive effects, designed for easy copy-paste integration into your applications. |  | [Demo](https://animata.design) |  |
-| snapcn | Video components that look like software, for Remotion: AI answer streams, terminal sessions, device frames, captions and full scenes. | [Github](https://github.com/snapcndev/snapcn.dev) | [Demo](https://snapcn.dev) |  |
+| snapcn | Video components that look like software, for Remotion: AI answer streams, terminal sessions, device frames, captions and full scenes. | [Github](https://github.com/snapcndev/snapcn) | [Demo](https://snapcn.dev) |  |
 
 ## Boilerplates & Starters
 


### PR DESCRIPTION
snapcn is an open-source library of Remotion components for product demo videos: AI answer streams, terminal sessions, device frames, captions and full scenes. Installed with the CLI and copied into your project as source, so there is no runtime dependency. MIT licensed, with a preview for every component.

https://snapcn.dev — https://github.com/snapcndev/snapcn.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `snapcn` to the Components & Libraries list with its description, repository link, and demo URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->