### PR TITLE
Add crafterui to Components & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@
 | solanauth | A responsive Solana wallet authentication and account modal for Next.js, featuring NextAuth integration and shadcn/ui components for modern dApps. |  | [Demo](https://solanauth.vercel.app/) |  |
 | vaul | Vaul is a dedicated React component for implementing drawer UIs, offering a simple way to add interactive panels for navigation or content. |  | [Demo](https://vaul.emilkowal.ski/) |  |
 | animata | Discover a free, open-source library of hand-crafted ReactJS animations and interactive effects, designed for easy copy-paste integration into your applications. |  | [Demo](https://animata.design) |  |
+| crafterui | Open-source motion and interaction components for React and Tailwind: 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns, installed with the shadcn CLI and owned as source. | [Github](https://github.com/SriSomanaath/crafterui) | [Demo](https://crafterui.com) |  |
 
 ## Boilerplates & Starters
 


### PR DESCRIPTION
crafterui is an open-source registry of motion and interaction components for React and Tailwind: 3D carousels, scroll letter reveals, a Dynamic Island, cursor hit-testing and rolling countdowns. Every component installs with the shadcn CLI and is copied into your project as source, so nothing is added to your runtime dependencies. MIT licensed, with a live demo and full source for each component.

```bash
npx shadcn@latest add https://crafterui.com/r/letter-reveal.json
```

https://crafterui.com — https://github.com/SriSomanaath/crafterui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CrafterUI to the Components & Libraries directory.
  * Included its description, repository link, and demo links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->